### PR TITLE
enclosing ' looks odd on cran.r-project.org/web/packages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rfisheries
-Title: 'Programmatic Interface to the 'openfisheries.org' API'
+Title: Programmatic Interface to the 'openfisheries.org' API
 Version: 0.2.99
 Date: 2016-02-18
 Authors@R: c(person("Karthik", "Ram", role = c("aut", "cre"), email =


### PR DESCRIPTION
Hello! I just noticed that the title is an odd-one-out on https://cran.r-project.org/web/packages/available_packages_by_name.html. This PR is just a minor suggestion. Please feel free to close if the superfluous enclosing `'`s are intended. Cheers :-)